### PR TITLE
FEAT: Adding dynamyc labels and dates for expenses and revenues screen

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -41,7 +41,8 @@ export default function home() {
         label: {
           text: formatDecimalToPercentage(chart.categoryPrice / chart.totalPrice) + "%",
           fontWeight: "bolder",
-          fill: theme.background.primary
+          fill: theme.background.primary,
+          fontSize: 16
         }
       });
 

--- a/app/transactions/expenses.tsx
+++ b/app/transactions/expenses.tsx
@@ -8,29 +8,57 @@ import { convert } from "@helpers/CurrencyConversion";
 import {Ionicons} from "@expo/vector-icons";
 import {Link} from "expo-router";
 import TransactionRepository, { Transaction as TransactionType } from "@database/repository/TransactionRepository";
+import { getFullMonth } from "@helpers/DateHelper";
 
 export default function expenses() {
 
   const { theme } = changeThemeStore();
 
+  const [selectedMonth, setSelectedMonth] = useState<number>(new Date().getMonth() + 1);
+  const [selectedYear, setSelectedYear] = useState<number>(new Date().getFullYear());
   const [transactions, setTransactions] = useState<TransactionType[]>([]);
-  const [transactionsPricesSum, setTransactionsPricesSum] = useState(0);
+  const [transactionsPricesSum, setTransactionsPricesSum] = useState<number>(0);
 
   const getAllTransactions = async () => {
-    setTransactions(await TransactionRepository.getAll());
+    setTransactions(await TransactionRepository.getAll(
+      selectedMonth.toString().padStart(2, '0'), selectedYear.toString()));
 
-    const repositoryResponse = await TransactionRepository.sumAllPrices("expense")
+    const repositoryResponse = await TransactionRepository.sumAllPrices(
+      "expense", selectedMonth.toString().padStart(2, '0'), selectedYear.toString())
     setTransactionsPricesSum(repositoryResponse.data.totalPrice);
+  }
+
+  const changeSelectedPeriod = (change: 'previous' | 'next') => {
+    if (change === 'next') {
+      if (selectedMonth === 11) {
+        setSelectedMonth(0);
+        setSelectedYear(selectedYear + 1);
+        return
+      }
+      setSelectedMonth(selectedMonth + 1);
+      return;
+    }
+
+    if (selectedMonth === 0) {
+      setSelectedMonth(11);
+      setSelectedYear(selectedYear - 1);
+      return
+    }
+    setSelectedMonth(selectedMonth - 1);
   }
 
   useEffect(() => {
     getAllTransactions();
-  }, [])
+  }, [selectedMonth]);
 
   return (
     <FixedScreen>
       <View className="my-4">
-        <MonthSlider month="Dezembro" />
+        <MonthSlider
+          month={ getFullMonth(selectedMonth) }
+          previousMonth={() => changeSelectedPeriod("previous")}
+          nextMonth={() => changeSelectedPeriod("next")}
+        />
       </View>
 
       <View className="flex flex-row gap-4 justify-center items-center w-full">
@@ -53,6 +81,7 @@ export default function expenses() {
                 value={transaction.price}
                 expenseName={transaction.description}
                 transactionId={transaction.id}
+                date={transaction.date}
               />
               {index < transactions.length && (
                 <View className="h-[1px] w-full bg-neutral-one"></View>

--- a/app/transactions/newExpense.tsx
+++ b/app/transactions/newExpense.tsx
@@ -30,10 +30,12 @@ export default function newExpense() {
 
   const handleTransactionInsert = async () => {
     try {
+      const formattedPrice
+            = Number(price.replace("R$ ", "").replace(",", "."));
       const result = await TransactionRepository.insert({
         description: description,
         type: 'expense',
-        price: Number(price),
+        price: formattedPrice,
         installments: Number(installments),
         paid: paid,
         date: dueDate.toISOString(),

--- a/app/transactions/newRevenue.tsx
+++ b/app/transactions/newRevenue.tsx
@@ -29,10 +29,12 @@ export default function newRevenue() {
 
   const handleTransactionInsert = async () => {
     try {
+      const formattedPrice
+        = Number(price.replace("R$ ", "").replace(",", "."));
       const result = await TransactionRepository.insert({
         description: description,
         type: 'revenue',
-        price: Number(price),
+        price: formattedPrice,
         installments: 1,
         paid: paid,
         date: dueDate.toISOString(),
@@ -56,7 +58,7 @@ export default function newRevenue() {
 
         <NewTransactionRow.Text icon={"document-text-outline"} placeholder={"Descrição"} onChange={setDescription} />
 
-        <NewTransactionRow.Text icon={"pricetag-outline"} placeholder={"R$ 0,00"} onChange={setPrice} />
+        <NewTransactionRow.Currency icon={"pricetag-outline"} placeholder={"R$ 0,00"} onChange={setPrice} />
 
         <NewTransactionRow.Select icon={"extension-puzzle-outline"} placeholder={"Categoria"} options={allCategories} onChange={setCategory} />
 

--- a/src/components/DoughnutChart.tsx
+++ b/src/components/DoughnutChart.tsx
@@ -4,7 +4,7 @@ import PieChart from "react-native-pie-chart";
 export type DoughnutSeries = {
   value: number;
   color: string;
-  label?: { text: string, fontWeight?: 'normal' | 'bold' | 'bolder', fill?: string };
+  label?: { text: string, fontWeight?: 'normal' | 'bold' | 'bolder', fill?: string, fonSize?: number };
 }
 
 export type DoughnutLabelData = {

--- a/src/components/label/Label.tsx
+++ b/src/components/label/Label.tsx
@@ -5,7 +5,6 @@ import CategoryRepository, {Category} from "@database/repository/CategoryReposit
 interface LabelProps {
   transactionId: number;
 }
-// TODO FIX THIS AND MAKE IT WORK WITH THE DATABASE DATA
 
 export default function Label({ transactionId }: LabelProps) {
 

--- a/src/components/label/Label.tsx
+++ b/src/components/label/Label.tsx
@@ -1,27 +1,37 @@
 import { Text, View } from "react-native";
-import React from "react";
-import transaction_categories from "../../mocks/transactions_categories";
-import categories from "../../mocks/categories";
+import React, {Suspense, useEffect} from "react";
+import CategoryRepository, {Category} from "@database/repository/CategoryRepository";
 
 interface LabelProps {
   transactionId: number;
 }
+// TODO FIX THIS AND MAKE IT WORK WITH THE DATABASE DATA
 
 export default function Label({ transactionId }: LabelProps) {
-  const pivot_table = transaction_categories.find(
-    (transaction_categories) =>
-      transactionId === transaction_categories.transaction_id
-  );
-  const category = categories.find(
-    (categories) => categories.id === pivot_table?.category_id
-  );
+
+  const [category, setCategory] = React.useState<Category>()
+
+  const fetchCategory = async () => {
+    const result = await CategoryRepository.findTransactionCategory(transactionId);
+    setCategory(result.data)
+  }
+
+  useEffect(() => {
+    fetchCategory();
+  }, [])
+
+  if (!category) {
+    return (
+      <Suspense/>
+    );
+  }
 
   return (
     <View
       className="rounded-xl px-2 m-0 py-[2px]"
-      style={{ backgroundColor: category?.colour }}
+      style={{ backgroundColor: category.colour }}
     >
-      <Text className="w-fit small text-center">{category?.description} </Text>
+      <Text className="w-fit small text-center">{category.description}</Text>
     </View>
   );
 }

--- a/src/components/month_slider/MonthSlider.tsx
+++ b/src/components/month_slider/MonthSlider.tsx
@@ -1,4 +1,4 @@
-import { Text, View } from "react-native";
+import {Pressable, Text, View} from "react-native";
 import React from "react";
 import { Ionicons } from "@expo/vector-icons";
 import changeThemeStore from "../../states/ColourTheme";
@@ -6,33 +6,35 @@ import Underline from "../underline/Underline";
 
 interface MonthSliderProps {
   month: string;
+  previousMonth: () => void;
+  nextMonth: () => void;
 }
 
-export default function MonthSlider({ month }: MonthSliderProps) {
+export default function MonthSlider({ month, previousMonth, nextMonth }: MonthSliderProps) {
   const { theme } = changeThemeStore();
 
   return (
     <View className="flex flex-row justify-center items-center gap-8">
-      <View>
+      <Pressable onPress={previousMonth}>
         <Ionicons
           name="chevron-back"
           size={22}
           color={theme.text.colours.normal}
         />
-      </View>
+      </Pressable>
 
       <View>
         <Text className="h3 text-normal">{month} </Text>
         <Underline />
       </View>
 
-      <View>
+      <Pressable onPress={nextMonth}>
         <Ionicons
           name="chevron-forward"
           size={22}
           color={theme.text.colours.normal}
         />
-      </View>
+      </Pressable>
     </View>
   );
 }

--- a/src/components/transaction/Transaction.tsx
+++ b/src/components/transaction/Transaction.tsx
@@ -4,12 +4,14 @@ import Ionicons from "@expo/vector-icons/Ionicons";
 import changeThemeStore from "@states/ColourTheme";
 import { convert } from "@helpers/CurrencyConversion";
 import Label from "@components/label/Label";
+import {formatTimestampDate} from "@helpers/DateHelper";
 
 interface TransactionProps {
   paid: boolean;
   value: number;
   expenseName: string;
   transactionId: number;
+  date: string;
 }
 
 export default function Transaction({ ...props }: TransactionProps) {
@@ -41,7 +43,9 @@ export default function Transaction({ ...props }: TransactionProps) {
       </View>
 
       <View>
-        <Text className="small text-alternative">28/08/2025 </Text>
+        <Text className="small text-alternative">
+          {formatTimestampDate(props.date)}
+        </Text>
         <View className="flex flex-row items-end">
           <Text className="small text-alternative">R$ </Text>
           <Text className="paragraph text-normal">{convert(props.value)} </Text>

--- a/src/database/repository/CategoryRepository.ts
+++ b/src/database/repository/CategoryRepository.ts
@@ -6,6 +6,11 @@ export type Category = {
   colour: string;
 };
 
+type DatabaseResponse = {
+  success: boolean,
+  data?: any
+}
+
 export default class CategoryRepository {
 
   public static async getAll(): Promise<Category[]> {
@@ -21,6 +26,24 @@ export default class CategoryRepository {
       console.log(result.lastInsertRowId.toLocaleString());
     } finally {
       await statement.finalizeAsync();
+    }
+  }
+
+  public static async findTransactionCategory(transactionId: number): Promise<DatabaseResponse> {
+    try {
+      const result = await db.getFirstAsync(`
+        SELECT * FROM category
+        WHERE
+            category.id = (
+                SELECT categoryId FROM transactions WHERE id = ${transactionId}    
+            )
+    `)
+      return { success: true, data: result };
+    }
+    catch (error)
+    {
+      console.log(error)
+      return { success: false }
     }
   }
 }

--- a/src/database/repository/TransactionRepository.ts
+++ b/src/database/repository/TransactionRepository.ts
@@ -18,8 +18,15 @@ type DatabaseResponse = {
 
 export default class TransactionRepository {
 
-  public static async getAll(): Promise<Transaction[]> {
-    return await db.getAllAsync("SELECT * FROM transactions;");
+  public static async getAll(monthNumber: string, yearNumber: string): Promise<Transaction[]> {
+    return await db.getAllAsync(`
+        SELECT * FROM 
+            transactions 
+        WHERE 
+            strftime('%m', date) = '${monthNumber}'
+        AND
+            strftime('%Y', date) = '${yearNumber}'
+    `);
   }
 
   public static async insert(transaction: Omit<Transaction, "id">): Promise<DatabaseResponse>  {
@@ -54,11 +61,21 @@ export default class TransactionRepository {
     }
   }
 
-  public static async sumAllPrices(transferType: Transaction["type"]): Promise<DatabaseResponse> {
+  public static async sumAllPrices(
+    transferType: Transaction["type"], monthNumber: string, yearNumber: string
+  ): Promise<DatabaseResponse> {
 
     try {
-      const result = await db.getFirstAsync(
-        `SELECT SUM(price) as totalPrice FROM transactions WHERE type = '${transferType}'`,
+      const result = await db.getFirstAsync(`
+          SELECT SUM(price) as totalPrice 
+          FROM transactions 
+          WHERE 
+              type = '${transferType}'
+          AND
+              strftime('%m', date) = '${monthNumber}'
+          AND
+              strftime('%Y', date) = '${yearNumber}'
+          `,
       )
       return { success: true, data: result };
     }
@@ -113,6 +130,12 @@ export default class TransactionRepository {
       catch(error) {
         console.log(error)
       }
+  }
+
+  public static test() {
+    return db.getFirstSync(`
+      SELECT strftime('%Y', date) FROM transactions
+    `)
   }
 
 }

--- a/src/helpers/DateHelper.ts
+++ b/src/helpers/DateHelper.ts
@@ -1,0 +1,26 @@
+export function formatTimestampDate(date: string) {
+  const newDate = new Date(date);
+  const day = String(newDate.getDate()).padStart(2, '0');
+  const month = String(newDate.getMonth() + 1).padStart(2, '0');
+  const year = String(newDate.getFullYear());
+  return `${day}/${month}/${year}`;
+}
+
+export function getFullMonth(monthNumber: number): string {
+  const months = [
+    'Janeiro',
+    'Fevereiro',
+    'Março',
+    'Abril',
+    'Maio',
+    'Junho',
+    'Julho',
+    'Agosto',
+    'Setembro',
+    'Outubro',
+    'Novembro',
+    'Dezembro'
+  ];
+
+  return months[monthNumber - 1];
+}


### PR DESCRIPTION
ISSUE #15 

## Description

Now the user is able to select the month he wants to see the information, selecting it through the 'Month Slider' at the top of the screen. Also, labels are queried from the database, not from mocks.

## Type

- [x] FEATURE
- [ ] CHORE
- [ ] FIX
- [ ] REFACTOR
- [ ] STYLE
